### PR TITLE
Swap coding rainbow reference on videos with coding train.

### DIFF
--- a/videos.html
+++ b/videos.html
@@ -14,8 +14,8 @@ permalink: /videos/
     <div class="more-videos content-wrapper article">
         <div class="line-charm"></div>
         <h2>YouTube</h2>
-        <p>All video tutorials can be found on my "Coding Rainbow" YouTube channel.</p>
-        <a href="http://youtube.com/shiffman" target="_blank" class="btn primary">CODING RAINBOW ON YOUTUBE</a>
+        <p>All video tutorials can be found on my "Coding Train" YouTube channel.</p>
+        <a href="http://youtube.com/shiffman" target="_blank" class="btn primary">THE CODING TRAIN ON YOUTUBE</a>
     </div>
 </section>
 


### PR DESCRIPTION
Just went on the site to find a video and noticed that the page was still referencing "Coding Rainbow"