### PR TITLE
Mixed content error

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -8,7 +8,7 @@
     <link rel="stylesheet" type="text/css" href="/css/main.css">
     <!-- Place favicon.ico and apple-touch-icon.png in the root directory -->
 
-    <script src="http://ajax.googleapis.com/ajax/libs/jquery/1/jquery.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1/jquery.js"></script>
     <script src="/js/main.js"></script>
     <script async src="//pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
     <script>

--- a/_includes/home-header.html
+++ b/_includes/home-header.html
@@ -13,8 +13,8 @@
     <li><a href="/learning/">LEARNING</a></li>
     <li><a href="/about/">ABOUT</a></li>
     <span class="line-charm"></span>
-    <li><a href="http://twitter.com/shiffman">TWITTER</a></li>
-    <li><a href="http://github.com/shiffman">GITHUB</a></li>
+    <li><a href="https://twitter.com/shiffman">TWITTER</a></li>
+    <li><a href="https://github.com/shiffman">GITHUB</a></li>
     <li><a href="https://www.patreon.com/codingtrain?ty=h" target="_blank">PATREON</a></li>
   </ul>
 </nav>

--- a/about.html
+++ b/about.html
@@ -10,8 +10,8 @@ permalink: /about/
     <div class="content-wrapper article">
         <br><br>
         <img src="/images/shiffman_rainbow.png" class="img-responsive"/>
-        <p>Daniel Shiffman works as an Associate Arts Professor at the <a href="http://itp.nyu.edu/" target="_blank">Interactive Telecommunications Program</a> at NYU’s <a href="http://www.tisch.nyu.edu/page/home" target="_blank">Tisch School of the Arts</a>.
-        <p>Originally from Baltimore, Daniel received a BA in Mathematics and Philosophy from <a href="http://www.yale.edu/" target="_blank">Yale University</a> and a Master’s Degree from the <a href="http://itp.nyu.edu/" target="_blank">ITP</a>. He is a director of <a href="http://processingfoundation.org">The Processing Foundation</a> and develops tutorials, examples, and libraries for <a href="http://www.processing.org/" target="_blank">Processing</a> and <a href="http://p5js.org">p5.js</a>. He is the author of <a href="http://www.learningprocessing.com/">Learning Processing: A Beginner’s Guide to Programming Images, Animation, and Interaction</a> and <a href="http://natureofcode.com/">The Nature of Code</a> (self-published via Kickstarter), an open source book about simulating natural phenomenon in Processing. He can be found <a href="http://youtube.com/user/shiffman">talking incessantly on the YouTube</a> about programming.</p>
+        <p>Daniel Shiffman works as an Associate Arts Professor at the <a href="https://itp.nyu.edu/" target="_blank">Interactive Telecommunications Program</a> at NYU’s <a href="https://www.tisch.nyu.edu/page/home" target="_blank">Tisch School of the Arts</a>.
+        <p>Originally from Baltimore, Daniel received a BA in Mathematics and Philosophy from <a href="https://www.yale.edu/" target="_blank">Yale University</a> and a Master’s Degree from the <a href="http://itp.nyu.edu/" target="_blank">ITP</a>. He is a director of <a href="https://processingfoundation.org">The Processing Foundation</a> and develops tutorials, examples, and libraries for <a href="https://www.processing.org/" target="_blank">Processing</a> and <a href="https://p5js.org">p5.js</a>. He is the author of <a href="http://www.learningprocessing.com/">Learning Processing: A Beginner’s Guide to Programming Images, Animation, and Interaction</a> and <a href="http://natureofcode.com/">The Nature of Code</a> (self-published via Kickstarter), an open source book about simulating natural phenomenon in Processing. He can be found <a href="https://youtube.com/user/shiffman">talking incessantly on the YouTube</a> about programming.</p>
 
 
     </div>
@@ -20,7 +20,7 @@ permalink: /about/
 <section class="right-container quick-links out">
     <h5>QUICK LINKS</h5>
     <div class="quick-link">
-        <a href="http://twitter.com/shiffman" target="_blank" class="secondary">Shiffman on Twitter</a>
+        <a href="https://twitter.com/shiffman" target="_blank" class="secondary">Shiffman on Twitter</a>
     </div>
     <div class="quick-link">
         <a href="https://github.com/shiffman" target="_blank" class="secondary">Shiffman on Github</a>

--- a/blog.html
+++ b/blog.html
@@ -30,7 +30,7 @@ permalink: /blog.deprecated/
         <a href="mailto:daniel@shiffman.net" class="secondary">Contact Daniel via Email</a>
     </div>
     <div class="quick-link">
-        <a href="http://twitter.com/shiffman" target="_blank" class="secondary">Shiffman on Twitter</a>
+        <a href="https://twitter.com/shiffman" target="_blank" class="secondary">Shiffman on Twitter</a>
     </div>
     <div class="quick-link">
         <a href="https://github.com/shiffman" target="_blank" class="secondary">Shiffman on Github</a>

--- a/books.html
+++ b/books.html
@@ -35,7 +35,7 @@ permalink: /books/
             <br>
             <a href="http://learningprocessing.com/" target="_blank" class="secondary">VISIT WEBSITE</a>
             <a href="https://github.com/shiffman/LearningProcessing" target="_blank" class="secondary">SOURCE CODE ON GITHUB</a>
-            <a href="http://www.amazon.com/gp/product/0123736021/ref=as_li_ss_tl?ie=UTF8&camp=1789&creative=390957&creativeASIN=0123736021&linkCode=as2&tag=shiffman-20" target="_blank" class="primary">GET THE BOOK</a>
+            <a href="https://www.amazon.com/gp/product/0123736021/ref=as_li_ss_tl?ie=UTF8&camp=1789&creative=390957&creativeASIN=0123736021&linkCode=as2&tag=shiffman-20" target="_blank" class="primary">GET THE BOOK</a>
         </div>
         <img class="book medium-hide" src="/images/book-lp.png" width="131px"/>
     </div>
@@ -46,7 +46,7 @@ permalink: /books/
             <br>
             <a href="http://natureofcode.com/" target="_blank" class="secondary">VISIT WEBSITE</a>
             <a href="https://github.com/shiffman/The-Nature-of-Code-Examples" target="_blank" class="secondary">SOURCE CODE ON GITHUB</a>
-            <a href="http://www.amazon.com/gp/product/0985930802/ref=as_li_ss_tl?ie=UTF8&camp=1789&creative=390957&creativeASIN=0985930802&linkCode=as2&tag=shiffman-20" target="_blank" class="primary">GET THE BOOK</a>
+            <a href="https://www.amazon.com/gp/product/0985930802/ref=as_li_ss_tl?ie=UTF8&camp=1789&creative=390957&creativeASIN=0985930802&linkCode=as2&tag=shiffman-20" target="_blank" class="primary">GET THE BOOK</a>
         </div>
         <img class="book medium-hide" src="/images/book-noc.png" width="131px"/>
     </div>

--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@ layout: home
         <div class="line-charm"></div>
         <h2>See all videos on YouTube</h2>
         <p>All of Daniel's video courses can be found on YouTube</p>
-        <a href="http://youtube.com/user/shiffman" target="_blank" class="btn primary">SEE ALL COURSES ON YOUTUBE</a>
+        <a href="https://youtube.com/user/shiffman" target="_blank" class="btn primary">SEE ALL COURSES ON YOUTUBE</a>
     </div>
     <!-- <div class="sign-up content">
       <span class="line-charm first"></span>
@@ -62,7 +62,7 @@ layout: home
     <div class="content">
       <h1>LEARNING PROCESSING</h1>
       <p>Creative Coding for the Total Beginner</p>
-      <a href="http://www.amazon.com/Learning-Processing-Second-Edition-Programming/dp/0123944430/ref=as_li_ss_tl?ie=UTF8&linkCode=sl1&tag=learniproces-20&linkId=757eff7b49e61c381b17a43c7dec3eee" class="primary">GET THE BOOK</a>
+      <a href="https://www.amazon.com/Learning-Processing-Second-Edition-Programming/dp/0123944430/ref=as_li_ss_tl?ie=UTF8&linkCode=sl1&tag=learniproces-20&linkId=757eff7b49e61c381b17a43c7dec3eee" class="primary">GET THE BOOK</a>
     </div>
     <img class="book" src="images/book-lp.png" width="131px"/>
   </div>
@@ -70,7 +70,7 @@ layout: home
     <div class="content">
       <h1>NATURE OF CODE</h1>
       <p>Simulations of Natural Systems</p>
-      <a href="http://www.amazon.com/gp/product/0985930802/ref=as_li_tf_tl?ie=UTF8&camp=1789&creative=9325&creativeASIN=0985930802&linkCode=as2&tag=natureofcode-20" target="_blank" class="primary">GET THE BOOK</a>
+      <a href="https://www.amazon.com/gp/product/0985930802/ref=as_li_tf_tl?ie=UTF8&camp=1789&creative=9325&creativeASIN=0985930802&linkCode=as2&tag=natureofcode-20" target="_blank" class="primary">GET THE BOOK</a>
     </div>
     <img class="book" src="images/book-noc.png" width="131px"/>
   </div>

--- a/learning.html
+++ b/learning.html
@@ -24,8 +24,8 @@ permalink: /learning/
             <img src="/images/atoz.png" width="800">
             This course focuses on programming strategies and techniques behind procedural analysis and generation of text-based data. We'll explore topics ranging from evaluating text according to its statistical properties to the automated production of text with probabilistic methods to text visualization. Students will learn server-side and client-side JavaScript programming and develop projects that can be shared and interacted with online. There will be weekly homework assignments as well as a final project.
         </p>
-        <a href="http://shiffman.net/a2z/" class="body-link primary">2016 course website</a>
-        <a href="http://shiffman.github.io/A2Z-F15/" class="body-link primary">2015 course website</a>
+        <a href="https://shiffman.net/a2z/" class="body-link primary">2016 course website</a>
+        <a href="https://shiffman.github.io/A2Z-F15/" class="body-link primary">2015 course website</a>
 
 
 
@@ -35,7 +35,7 @@ permalink: /learning/
             <img src="/images/kinect.png" width="800">
             The Microsoft Kinect can be used with Processing for a variety of computer vision applications.
         </p>
-        <a href="http://shiffman.net/p5/kinect/" class="body-link primary">Visit the online tutorial</a>
+        <a href="https://shiffman.net/p5/kinect/" class="body-link primary">Visit the online tutorial</a>
 
 
     </div>
@@ -59,16 +59,16 @@ permalink: /learning/
         <a href="https://github.com/shiffman/Faces" target="_blank" class="secondary">Face It</a>
     </div>
     <div class="quick-link">
-        <a href="http://itp.nyu.edu/varwiki/BigScreens/BigScreens" target="_blank" class="secondary">Big Screens</a>
+        <a href="https://itp.nyu.edu/varwiki/BigScreens/BigScreens" target="_blank" class="secondary">Big Screens</a>
     </div>
 
     <br>
     <h5>OPEN SOURCE PROJECTS</h5>
     <div class="quick-link">
-        <a href="http://processingfoundation.org/" target="_blank" class="secondary">The Processing Foundation</a>
+        <a href="https://processingfoundation.org/" target="_blank" class="secondary">The Processing Foundation</a>
     </div>
     <div class="quick-link">
-        <a href="http://shiffman.net/p5/kinect/" target="_blank" class="secondary">Open Kinect for Processing</a>
+        <a href="https://shiffman.net/p5/kinect/" target="_blank" class="secondary">Open Kinect for Processing</a>
     </div>
     <div class="quick-link">
         <a href="https://github.com/shiffman/PBox2D" target="_blank" class="secondary">Box2D for Processing</a>


### PR DESCRIPTION
To prevent a mixed content error (as HTTPS is now used):

![image](https://user-images.githubusercontent.com/29151620/41201075-745d996e-6cb1-11e8-9af3-212990d7d46e.png)

As a result, all jquery-dependant content doesn't work