### PR TITLE
Updated Botwiki link.

### DIFF
--- a/a2z/04_twitter_bot.md
+++ b/a2z/04_twitter_bot.md
@@ -20,7 +20,7 @@ permalink: /a2z/twitter-bots/
 ## Bot lists
 * [Bot twitter list](https://twitter.com/shiffman/lists/bots)
 * [More comprehensive twitter bot list](https://twitter.com/ckolderup/lists/the-fall-of-humanity/members)
-* [Bot wiki](https://botwiki.org/tag/twitterbot)
+* [Bot wiki](https://botwiki.org/bot/?networks=twitter-bots)
 * [Another bot wiki](https://github.com/shiffman/A2Z-F15/wiki/Twiter-Bots)
 
 ## Read


### PR DESCRIPTION
The site structure changed after recent migration to WordPress, so I updated the link that lists all Twitter bots on Botwiki.