### PR TITLE
missing page titles

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,7 +1,7 @@
 <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <title></title>
+    <title>{{ page.title }} | Daniel Shiffman</title>
     <meta name="description" content="">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 

--- a/books.html
+++ b/books.html
@@ -1,5 +1,6 @@
 ---
 layout: default
+title: Books
 permalink: /books/
 ---
 

--- a/index.html
+++ b/index.html
@@ -1,5 +1,6 @@
 ---
 layout: home
+title: Home
 ---
 
 <section class="left-container out home">

--- a/learning.html
+++ b/learning.html
@@ -1,5 +1,6 @@
 ---
 layout: default
+title: Learning
 permalink: /learning/
 ---
 

--- a/videos.html
+++ b/videos.html
@@ -1,5 +1,6 @@
 ---
 layout: default
+title: Videos
 permalink: /videos/
 ---
 


### PR DESCRIPTION
fix for missing page titles issue https://github.com/shiffman/shiffman.net/issues/62
Title for the pages is now dynamically update based on title property on the post/page.