### PR TITLE
Accessibility Updates #2

### DIFF
--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -559,7 +559,6 @@ a.body-link {
                 text-transform: uppercase;
                 display: block;
                 letter-spacing: 0.6px;
-                outline: none;
                 border: none;
                 background: none;
                 cursor: pointer;
@@ -568,7 +567,6 @@ a.body-link {
     }
 }
 input:focus {
-    outline: none;
     border: none;
 }
 // BOOKS PAGE


### PR DESCRIPTION
CSS ```outline: none;``` should never be used. Keyboard users won't know which element is being focused on.