### PR TITLE
Close the Menu Bar when Quick Links is opened

### DIFF
--- a/js/home.js
+++ b/js/home.js
@@ -54,7 +54,12 @@ $(document).ready(function() {
 				rightActive = true;
 				enableQuicklinks();
 				qlInput.focus();
+				if (document.body.classList.contains('active')) {
+					document.body.classList.remove('active');
+					document.getElementById('menu-button').classList.remove('active');
+					// disableNavLinks();
 				}
+			}
 		}
 		function enableQuicklinks() {
 			quicklinksButton.html('Hide quick links');


### PR DESCRIPTION
On mobile, I face this really weird issue where the links menu overlaps the left menu bar.

![image](https://user-images.githubusercontent.com/66690593/167438221-1a0d7d3d-00f8-4088-9032-aa867cee78a8.png)

Closing the menu bar when opening the links menu hopefully solves this.