### PR TITLE
Fix YouTube Channel Links

### DIFF
--- a/videos.html
+++ b/videos.html
@@ -16,7 +16,7 @@ permalink: /videos/
         <div class="line-charm"></div>
         <h2>YouTube</h2>
         <p>All video tutorials can be found on my "Coding Train" YouTube channel.</p>
-        <a href="http://youtube.com/shiffman" target="_blank" class="btn primary">THE CODING TRAIN ON YOUTUBE</a>
+        <a href="https://www.youtube.com/TheCodingTrain" target="_blank" class="btn primary">THE CODING TRAIN ON YOUTUBE</a>
     </div>
 </main>
 <button class="mobile-quick-links" aria-controls="quicklinks-section" aria-haspopup="true" id="quicklinks-btn"></button>        
@@ -29,7 +29,7 @@ permalink: /videos/
         <a href="http://patreon.com/codingtrain" class="secondary" target="_blank"><span>SUPPORT ON PATREON</span></a>
     </div>
     <div class="quick-link">
-        <a href="https://www.youtube.com/channel/UCvjgXvBlbQiydffZU7m1_aw" target="_blank" class="secondary">SEE ALL ON YOUTUBE</a>
+        <a href="https://www.youtube.com/TheCodingTrain" target="_blank" class="secondary">SEE ALL ON YOUTUBE</a>
     </div>
 </aside>
 


### PR DESCRIPTION
Super small fix ;)

- Updated one link on your `/videos` page that was pointing towards what seems like a private account of yours
- While at it, rewrote one link that used your channel id and replaced it with the same link using your actual channel name