### PR TITLE
Remove border on .mobile-quick-links

### DIFF
--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -234,6 +234,7 @@ z-index: 2;
     display: block;
     border-radius: 20px;
     z-index: 3; /* quicklink button needs to be on top*/
+    border: none;
     @media only screen and (max-width: $breakpoint-small) {
         display: block;
     }


### PR DESCRIPTION
Border on chrome is ugly and does not fit page esthetic.

![](https://cdn.discordapp.com/attachments/814409474147614730/1062111346960891934/image.png)