### PR TITLE
A to Z quick links fix

### DIFF
--- a/_layouts/a2z-post.html
+++ b/_layouts/a2z-post.html
@@ -20,52 +20,54 @@ layout: default
   <span class="line-charm first"></span>
   <div class="content-wrapper article a2z">{{ content }}</div>
 </section>
-<button class="mobile-quick-links" aria-controls="quicklinks-section" aria-haspopup="true" id="quicklinks-btn">VIEW QUICK LINKS</button>
+<button class="mobile-quick-links" aria-controls="quicklinks-section" aria-haspopup="true" id="quicklinks-btn">
+  VIEW QUICK LINKS
+</button>
 <aside class="right-container quick-links out" id="quicklinks-section">
   <div class="quick-link">
-    <a href="a2z/" class="secondary">About the course</a>
+    <a href="/a2z/" class="secondary">About the course</a>
   </div>
   <h3>Tutorials</h3>
   <div class="quick-link">
-    <a href="a2z/intro" class="secondary">Introduction - p5.js, JavaScript, and Strings</a>
+    <a href="/a2z/intro" class="secondary">Introduction - p5.js, JavaScript, and Strings</a>
   </div>
   <div class="quick-link">
-    <a href="a2z/regex" class="secondary">Regular Expressions</a>
+    <a href="/a2z/regex" class="secondary">Regular Expressions</a>
   </div>
   <div class="quick-link">
-    <a href="a2z/closures" class="secondary">Closures</a>
+    <a href="/a2z/closures" class="secondary">Closures</a>
   </div>
   <div class="quick-link">
-    <a href="a2z/data-apis" class="secondary">Libraries, Data, and APIs</a>
+    <a href="/a2z/data-apis" class="secondary">Libraries, Data, and APIs</a>
   </div>
   <div class="quick-link">
-    <a href="a2z/server-node" class="secondary">Server-side programming with node.js</a>
+    <a href="/a2z/server-node" class="secondary">Server-side programming with node.js</a>
   </div>
   <div class="quick-link">
-    <a href="a2z/twitter-bots" class="secondary">Twitter API and bots with node.js</a>
+    <a href="/a2z/twitter-bots" class="secondary">Twitter API and bots with node.js</a>
   </div>
   <div class="quick-link">
-    <a href="a2z/bot-ec2" class="secondary">Deploy Bot to Amazon EC2</a>
+    <a href="/a2z/bot-ec2" class="secondary">Deploy Bot to Amazon EC2</a>
   </div>
   <div class="quick-link">
-    <a href="a2z/bot-heroku" class="secondary">Deploy Bot to Heroku</a>
+    <a href="/a2z/bot-heroku" class="secondary">Deploy Bot to Heroku</a>
   </div>
   <div class="quick-link">
-    <a href="a2z/text-analysis" class="secondary">Text Analysis</a>
+    <a href="/a2z/text-analysis" class="secondary">Text Analysis</a>
   </div>
   <div class="quick-link">
-    <a href="a2z/markov" class="secondary">N-Grams and Markov Chains</a>
+    <a href="/a2z/markov" class="secondary">N-Grams and Markov Chains</a>
   </div>
   <div class="quick-link">
-    <a href="a2z/cfg" class="secondary">Context-Free Grammar</a>
+    <a href="/a2z/cfg" class="secondary">Context-Free Grammar</a>
   </div>
   <div class="quick-link">
-    <a href="a2z/node-api" class="secondary">Creating an API in Node</a>
+    <a href="/a2z/node-api" class="secondary">Creating an API in Node</a>
   </div>
   <div class="quick-link">
-    <a href="a2z/firebase" class="secondary">Database as Service: Firebase</a>
+    <a href="/a2z/firebase" class="secondary">Database as Service: Firebase</a>
   </div>
   <div class="quick-link">
-    <a href="a2z/chrome-ext" class="secondary">Chrome Extensions</a>
+    <a href="/a2z/chrome-ext" class="secondary">Chrome Extensions</a>
   </div>
 </aside>


### PR DESCRIPTION
The links in the "quick links" panel for "A to Z" were all broken (relative vs absolute).

https://shiffman-archive.netlify.app/a2z/

![CleanShot 2024-07-28 at 09 59 55@2x](https://github.com/user-attachments/assets/301739c1-1d98-4f6e-9d26-4a331c816aac)

